### PR TITLE
Am revizuit imnurile pentru seara de tineret de luni, 25 septembrie.

### DIFF
--- a/candidates/resurse_crestine_raw/Iolu Cornel - La inceput era Cuvantul - Cuvantul intrupat.txt
+++ b/candidates/resurse_crestine_raw/Iolu Cornel - La inceput era Cuvantul - Cuvantul intrupat.txt
@@ -1,5 +1,5 @@
 [title]
-La început era Cuvântul {alternative: {Cuvântul întrupat}, composer: {Iolu Cornel}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {212152}, id: {6u6gGhJNfi1gd46hjrMTDc}, contentHash: {b1e8e5}}
+La început era Cuvântul {alternative: {Cuvântul întrupat}, composer: {Iolu Cornel}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {212152}, id: {6u6gGhJNfi1gd46hjrMTDc}, contentHash: {44cd91}}
 
 [sequence]
 v1.1,v1.2,c,v1.1,v1.2,c,e,c

--- a/verified/all/Tinerii din Biserica Emanuel Sibiu - E timp de har.txt
+++ b/verified/all/Tinerii din Biserica Emanuel Sibiu - E timp de har.txt
@@ -1,5 +1,5 @@
 [title]
-E timp de har {alternative: {*}, composer: {Tinerii din Biserica Emanuel Sibiu}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {*}, id: {9c5dqWg5pmZF4eEsSd2fZ9}, contentHash: {c56908}}
+E timp de har {alternative: {*}, composer: {Tinerii din Biserica Emanuel Sibiu}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {*}, id: {9c5dqWg5pmZF4eEsSd2fZ9}, contentHash: {ad2b14}}
 
 [sequence]
 v1,c,v2,c,b,c

--- a/verified/trupe_lauda_si_inchinare/Shane Barnard & Joe Rigney - L-am cautat si L-am gasit - Psalmul 34 Psalm 34.txt
+++ b/verified/trupe_lauda_si_inchinare/Shane Barnard & Joe Rigney - L-am cautat si L-am gasit - Psalmul 34 Psalm 34.txt
@@ -1,5 +1,5 @@
 [title]
-L-am căutat și L-am găsit {alternative: {Psalmul 34; Psalm 34}, composer: {Shane Barnard & Joe Rigney}, writer: {Nicoleta Mascaș, Salomeea Handaric, Sergiu Strete & Razvan Reste, trad.}, arranger: {*}, interpreter: {BBSO}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {214233}, id: {2QAqHiij5zSxSQeWmQYBki}, contentHash: {04b138}}
+L-am căutat și L-am găsit {alternative: {Psalmul 34; Psalm 34}, composer: {Shane Barnard & Joe Rigney}, writer: {Nicoleta Mascaș}, arranger: {*}, interpreter: {BBSO}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {214233}, id: {2QAqHiij5zSxSQeWmQYBki}, contentHash: {67bb70}}
 
 [sequence]
 v1,v2,c,v3,c,b,c,e

--- a/verified/trupe_lauda_si_inchinare/The Messengers - Inima mea tanjeste dupa curtile Tale.txt
+++ b/verified/trupe_lauda_si_inchinare/The Messengers - Inima mea tanjeste dupa curtile Tale.txt
@@ -1,5 +1,5 @@
 [title]
-Inima mea tânjește după curțile Tale {alternative: {*}, composer: {The Messengers}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {4276}, id: {swfMGwVSgR21fK6XhXZsWt}, contentHash: {f066b0}}
+Inima mea tânjește după curțile Tale {alternative: {*}, composer: {The Messengers}, writer: {*}, arranger: {*}, interpreter: {*}, band: {*}, key: {*}, tempo: {*}, tags: {*}, version: {*}, genre: {*}, rcId: {4276}, id: {swfMGwVSgR21fK6XhXZsWt}, contentHash: {e6bf41}}
 
 [sequence]
 v1.1,v1.2,c


### PR DESCRIPTION
#### Motivation and context

<!--- Why is this change required? -->

#### Checklist:

- [x] I only use the allowed chars

În acest set de imnuri există două situații speciale în cazul cărora am preferat să nu modific textul original al cântărilor, fiindcă acest lucru ar crea dificultăți celor ce cântă. Este vorba de imnul _L-am căutat și L-am găsit_, în care apar multiple anacolute, adică greșeli gramatical-sintactice ce constau în treceri bruște și adesea ilogice de la o persoană la alta. În cazul imnului în discuție, un astfel de procedeu se observă în versul 34: „Veșnic vom cânta pentru Domnul meu”. O posibilă rescriere a acestui vers ar fi: _Veșnic vom cânta pentru al nost’ Domn_. Poate ai tu o idee mai bună. 

A doua situație apare în imnul _Domnul stă în fruntea oastei Lui_, în versul 26, unde rescrierea corectă ar fi: „Să intrăm în țara pe care ne-a promis-o”.     
      