### PR TITLE
feat: Use default language in songbook

### DIFF
--- a/LaTeX/songbook/bes-songbook.template.txt
+++ b/LaTeX/songbook/bes-songbook.template.txt
@@ -10,7 +10,6 @@
 \documentclass{scrartcl}
 
 \usepackage{datetime} % For custom date and time formatting
-\usepackage[romanian]{babel} % For Romanian language support
 
 \usepackage{scrextend} % Compatibility layer
 \usepackage[full]{leadsheets}


### PR DESCRIPTION
#### Motivation and context

Because the translation in leadsheets is now broken.

#### Checklist:

- [x] I only use the allowed chars
